### PR TITLE
Add missing argument 'project_settings_cache'

### DIFF
--- a/themes_config.py
+++ b/themes_config.py
@@ -567,7 +567,7 @@ def getGroupThemes(config, permissions, configGroup, result, resultGroup, projec
                 "items": [],
                 "subdirs": []
             }
-            getGroupThemes(config, permissions, group, result, groupEntry)
+            getGroupThemes(config, permissions, group, result, groupEntry, project_settings_cache)
             resultGroup["subdirs"].append(groupEntry)
 
 


### PR DESCRIPTION
TypeError: getGroupThemes() missing 1 required positional argument: 'project_settings_cache'